### PR TITLE
V2.5.8

### DIFF
--- a/EasySave/EasySaveGUI/ViewModel/ShowLogsViewModel.cs
+++ b/EasySave/EasySaveGUI/ViewModel/ShowLogsViewModel.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Input;
+using static Logs;
+
+namespace EasySaveGUI.ViewModel
+{
+    /// <summary>
+    /// ViewModel responsible for handling log display in the EasySave application.
+    /// </summary>
+    public class ShowLogsViewModel : BaseViewModel
+    {
+        /// <summary>
+        /// Collection of log entries displayed in the DataGrid.
+        /// </summary>
+        public ObservableCollection<LogEntry> Logs { get; set; }
+
+        private string _inputWantedDate;
+
+        public ICommand ShowLogsCommand { get; }
+
+
+        public string InputWantedDate
+        {
+            get => _inputWantedDate;
+            set { _inputWantedDate = value; OnPropertyChanged(); }
+        }
+        public ShowLogsViewModel()
+        {
+            Logs = new ObservableCollection<LogEntry>();
+            ShowLogsCommand = new RelayCommand(_ => LogsSearch());
+        }
+
+        /// <summary>
+        /// Executes the log search based on the provided or default date.
+        /// </summary>
+        private void LogsSearch()
+        {
+            string wantedDate = InputWantedDate == "" ? $"{DateTime.Now:dd-MM-yyyy}" : InputWantedDate;
+            wantedDate = "16-02-2025";
+            string filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../../../Logs/Logs", $"{wantedDate}.json");
+
+            if (!Regex.IsMatch(wantedDate, "^(0[1-9]|[12][0-9]|3[01])-(0[1-9]|1[0-2])-\\d{4}$"))
+            {
+                MessageBox.Show(LanguageHelper.Translate("WPF_FormatLog") + " : 15-02-2024, " + LanguageHelper.Translate("WPF_Format") + " : jj-MM-aaaa).");
+                return;
+            }
+
+            if (!File.Exists(filePath))
+            {
+                MessageBox.Show(LanguageHelper.Translate("WPF_FileNotFound") + $"{wantedDate}");
+                return;
+            }
+            LoadLogs(filePath);
+        
+        }
+
+        /// <summary>
+        /// Loads log entries from a specified file and updates the observable collection.
+        /// </summary>
+        /// <param name="filePath">The path of the log file to be loaded.</param>
+        public void LoadLogs(string filePath)
+        {
+            var logsFromFile = ReadGeneralLog(filePath);
+
+            Logs.Clear();
+            foreach (var log in logsFromFile)
+            {
+                Logs.Add(log);
+            }
+
+
+        }
+
+    }
+}

--- a/EasySave/EasySaveGUI/Views/ShowLogs.xaml
+++ b/EasySave/EasySaveGUI/Views/ShowLogs.xaml
@@ -7,7 +7,16 @@
         Style="{StaticResource WindowStyleWithRoundedCorners}"
         WindowStartupLocation="CenterScreen">
 
-    <Grid DataContext="{x:Static local:LanguageHelper.Instance}">
+    <Window.Resources>
+        <local:LanguageHelper x:Key="LangHelper" />
+    </Window.Resources>
+
+    <Window.DataContext>
+        <local:ShowLogsViewModel />
+
+    </Window.DataContext>
+    
+    <Grid>
         <Grid.RowDefinitions>
             <!-- Header -->
             <RowDefinition Height="115"/>
@@ -23,7 +32,7 @@
         <Grid Grid.Row ="1">
             <!-- Title Page -->
             <Label x:Name="LabelLogsTitlePage"
-                Content="{Binding [ControllerView_ViewLogs]}"
+                Content="{Binding Source={StaticResource LangHelper}, Path=[ControllerView_ViewLogs]}"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Top"
                 FontSize="40"
@@ -36,6 +45,7 @@
 
             <!-- Page Content -->
             <TextBox x:Name="InputLogsSearch" 
+                 Text="{Binding InputWantedDate, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}"
                  Width="246" 
                  Height="40" 
                  FontSize="16" 
@@ -44,8 +54,8 @@
                  Margin="297,82,0,0"/>
 
             <Button x:Name="ButtonLogsSearch" 
-                Content="{Binding [WPF_Search]}" 
-                Click="ButtonLogsSearchClick"
+                Content="{Binding Source={StaticResource LangHelper}, Path=[WPF_Search]}" 
+              
                 HorizontalAlignment="Left" 
                 Height="40" 
                 Margin="559,82,0,0" 
@@ -53,10 +63,12 @@
                 Width="122" 
                 FontSize="16" 
                 FontWeight="Bold"
-                Style="{StaticResource CustomButtonStyle}"/>
+                Style="{StaticResource CustomButtonStyle}" 
+                Command="{Binding ShowLogsCommand}"/>
 
             <DataGrid 
-              x:Name="DataGridLogs"
+              ItemsSource="{Binding Logs}"
+              x:Name="DataGridLogs" 
               Margin="18,140,18,10" 
               Style="{StaticResource CustomDataGridStyle}"
               AutoGenerateColumns="False">

--- a/EasySave/EasySaveGUI/Views/ShowLogs.xaml.cs
+++ b/EasySave/EasySaveGUI/Views/ShowLogs.xaml.cs
@@ -15,53 +15,17 @@ namespace EasySaveGUI
     /// </summary>
     public partial class ShowLogs : Window
     {
-        public ObservableCollection<LogEntry> Logs { get; set; }
         public ShowLogs()
         {
             InitializeComponent();
 
-            DataContext = LanguageHelper.Instance;
 
-            this.DataContext = this; // Sets the current class as the data source
+            ShowLogsViewModel objViewModel = new ShowLogsViewModel();
 
-            LoadLogs(GetCurrentFileDate());
-        }
+            DataContext = objViewModel;
+            
+            objViewModel.LoadLogs(Path.Combine(Directory.GetCurrentDirectory(), "../../../../Logs/Logs", $"{DateTime.Now:dd-MM-yyyy}.json"));
 
-        private void LoadLogs(string filePath)
-        {
-            var logsFromFile = ReadGeneralLog(filePath);
-            Debug.WriteLine(Path.GetFullPath(filePath));
-            Debug.WriteLine(logsFromFile);
-
-            Logs = new ObservableCollection<LogEntry>(logsFromFile);
-            DataGridLogs.ItemsSource = Logs;
-        }
-
-
-        private string GetCurrentFileDate()
-        {
-            return Path.Combine(Directory.GetCurrentDirectory(), "../../../../Logs/Logs", $"{DateTime.Now:dd-MM-yyyy}.json");
-        }
-
-        private void ButtonLogsSearchClick(object sender, RoutedEventArgs e)
-        {
-            string wantedDate = InputLogsSearch.Text;
-            wantedDate = wantedDate == "" ? $"{DateTime.Now:dd-MM-yyyy}" : wantedDate;
-
-            string filePath = Path.Combine(Directory.GetCurrentDirectory(), "../../../../Logs/Logs", $"{wantedDate}.json");
-
-            if (!Regex.IsMatch(wantedDate, "^(0[1-9]|[12][0-9]|3[01])-(0[1-9]|1[0-2])-\\d{4}$"))
-            {
-                MessageBox.Show(LanguageHelper.Translate("WPF_FormatLog") + " : 15-02-2024, " +LanguageHelper.Translate("WPF_Format")+ " : jj-MM-aaaa).");
-                return;
-            }
-
-            if (!File.Exists(filePath))
-            {
-                MessageBox.Show(LanguageHelper.Translate("WPF_FileNotFound") + $"{wantedDate}");
-                return;
-            }
-            LoadLogs(filePath);
         }
     }
 }


### PR DESCRIPTION
```markdown
# 🚀 Notes de version – Mise à jour de l'affichage des logs  

## 🔹 Résumé  
Cette mise à jour introduit **`ShowLogsViewModel`** pour gérer l'affichage des logs, améliorant la **séparation des responsabilités** et la **maintenabilité** du code. L’interface se lie désormais au ViewModel, et le code redondant a été supprimé.  

## 🆕 Changements principaux  
- **Ajout de `ShowLogsViewModel`** : Gestion du chargement et de la recherche des logs.  
- **Mise à jour de `ShowLogs.xaml`** : Liaison des éléments au ViewModel.  
- **Suppression du code dans `ShowLogs.xaml.cs`** : Toute la logique est centralisée dans le ViewModel.  
```