### PR TITLE
V2.9.0

### DIFF
--- a/CryptoSoftWPF/CryptoSoftConsole/Controller.cs
+++ b/CryptoSoftWPF/CryptoSoftConsole/Controller.cs
@@ -6,21 +6,30 @@ namespace CryptoConsoleApp
     {
         private readonly ConsoleView _view;
 
+        /// <summary>
+        /// Constructor of the controller
+        /// </summary>
+        /// <param name="view"> The view of the application </param>
         public EncryptionController(ConsoleView view)
         {
             _view = view;
         }
 
+        /// <summary>
+        /// Run the application and display the main menu
+        /// </summary>
         public void Run()
         {
             bool continueRunning = true;
 
             while (continueRunning)
             {
+                // Display the title of the application and get the file path and encryption key
                 _view.DisplayTitle();
                 string filePath = _view.GetFilePath();
                 string encryptKey = _view.GetEncryptionKey();
 
+                // Encrypt the file if the user confirms the operation
                 if (_view.ConfirmEncryption())
                 {
                     _view.ShowMessage("Encryption in progress...");
@@ -32,6 +41,7 @@ namespace CryptoConsoleApp
                     _view.ShowMessage("Operation canceled.");
                 }
 
+                // Ask the user if he wants to encrypt another file or exit the application
                 _view.EncryptAgain();
                 string continueResponse = Console.ReadLine() ?? string.Empty;
 

--- a/CryptoSoftWPF/CryptoSoftConsole/Program.cs
+++ b/CryptoSoftWPF/CryptoSoftConsole/Program.cs
@@ -1,13 +1,32 @@
-﻿namespace CryptoConsoleApp
+﻿using System;
+using System.Threading;
+
+namespace CryptoConsoleApp
 {
     class Program
     {
         static void Main()
         {
-            var view = new ConsoleView();
+            // Mutex to prevent multiple instances of the application
+            bool createdNew;
+            using (Mutex mutex = new Mutex(true, "CryptoSoftCONSOLE_Mutex", out createdNew))
+            {
+                // If the mutex is already created, it means that the application is already running
+                if (!createdNew)
+                {
+                    Console.WriteLine("CryptoSoft is already running. Please close the current instance before starting a new one.");
+                    Thread.Sleep(4000);
+                    return; 
+                }
 
-            var controller = new EncryptionController(view);
-            controller.Run();
+                // Start the application if it is not already running
+                var view = new ConsoleView();
+                var controller = new EncryptionController(view);
+                controller.Run();
+
+                // Prevent the mutex from being garbage collected
+                GC.KeepAlive(mutex);
+            }
         }
     }
 }

--- a/CryptoSoftWPF/CryptoSoftWPF/App.xaml.cs
+++ b/CryptoSoftWPF/CryptoSoftWPF/App.xaml.cs
@@ -1,14 +1,32 @@
-﻿using System.Configuration;
-using System.Data;
+﻿using System;
+using System.Threading;
 using System.Windows;
 
 namespace CryptoSoftWPF
 {
-    /// <summary>
-    /// Interaction logic for App.xaml
-    /// </summary>
     public partial class App : Application
     {
-    }
+        // Mutex to prevent multiple instances of the application 
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            // Mutex to prevent multiple instances of the application
+            bool createdNew;
+            using (Mutex mutex = new Mutex(true, "CryptoSoftWPF_Mutex", out createdNew))
+            {
+                // If the mutex is already created, it means that the application is already running
+                if (!createdNew)
+                {
+                    MessageBox.Show("CryptoSoft is already running!", "Warning", MessageBoxButton.OK, MessageBoxImage.Warning);
+                    Application.Current.Shutdown();
+                    return;
+                }
 
+                // Start the application if it is not already running
+                base.OnStartup(e);
+
+                // Prevent the mutex from being garbage collected
+                GC.KeepAlive(mutex);
+            }
+        }
+    }
 }


### PR DESCRIPTION
##  **Console Application**
- **Mono-Instance** : Ajout d'un `Mutex` pour empêcher le lancement de plusieurs instances simultanées.
- Si une instance est déjà en cours, un message s'affiche : _"CryptoSoft is already running!"_ et l'application se ferme.
- Testé et fonctionnel pour garantir qu'une seule instance peut être exécutée.

### **Changements clés** :
- Utilisation d'un `Mutex` unique pour vérifier les instances.
- Fermeture immédiate de l'application en cas de doublon.

---

## **WPF Application**
- **Mono-Instance** : Implémentation d'un `Mutex` similaire à la version Console pour l'application WPF.
- Si une autre instance est déjà lancée, un message prévient l'utilisateur et l'application se ferme.

### **Changements clés** :
- Implémentation de la même logique de `Mutex` que pour l'application Console.
- Message d'avertissement et fermeture automatique en cas de duplication.
